### PR TITLE
docs: add jsdoc annotations to typescript modules

### DIFF
--- a/src/api/clients/httpClient.ts
+++ b/src/api/clients/httpClient.ts
@@ -1,5 +1,9 @@
 import axios from 'axios';
 
+/**
+ * Axios instance configured to communicate with the application's backend API.
+ * @see https://axios-http.com/docs/instance
+ */
 const httpClient = axios.create({
   baseURL: '/api',
   timeout: 10_000

--- a/src/api/dto/user.dto.ts
+++ b/src/api/dto/user.dto.ts
@@ -1,5 +1,11 @@
 import type { User } from '@/types/user';
 
+/**
+ * Normalize user data returned by the API to match UI expectations.
+ *
+ * @param data - Raw user records returned by the backend.
+ * @returns A new array containing normalized user objects.
+ */
 export const mapUserResponse = (data: User[]): User[] =>
   data.map((user) => ({
     ...user,

--- a/src/api/endpoints/auth.ts
+++ b/src/api/endpoints/auth.ts
@@ -1,19 +1,36 @@
 import httpClient from '../clients/httpClient';
 
+/**
+ * Payload containing the credentials required to initiate a login request.
+ */
 export interface LoginPayload {
   email: string;
   password: string;
 }
 
+/**
+ * Response body returned by the authentication endpoint when login succeeds.
+ */
 export interface LoginResponse {
   token: string;
 }
 
+/**
+ * Authenticate a user using the provided credentials and retrieve the session token.
+ *
+ * @param payload - User credentials collected from the login form.
+ * @returns A promise resolving to the authentication response containing a token.
+ */
 export const login = async (payload: LoginPayload) => {
   const { data } = await httpClient.post<LoginResponse>('/auth/login', payload);
   return data;
 };
 
+/**
+ * Terminate the current user session on the server.
+ *
+ * @returns A promise that resolves once the logout operation completes.
+ */
 export const logout = async () => {
   await httpClient.post('/auth/logout');
 };

--- a/src/api/endpoints/index.ts
+++ b/src/api/endpoints/index.ts
@@ -1,2 +1,5 @@
+/**
+ * Re-exported REST API endpoint modules grouped by domain.
+ */
 export * as authApi from './auth';
 export * as usersApi from './users';

--- a/src/api/endpoints/users.ts
+++ b/src/api/endpoints/users.ts
@@ -2,6 +2,11 @@ import type { User } from '@/types/user';
 
 import httpClient from '../clients/httpClient';
 
+/**
+ * Retrieve the list of users from the backend service.
+ *
+ * @returns A promise resolving to the collection of users.
+ */
 export const fetchUsers = async () => {
   const { data } = await httpClient.get<User[]>('/users');
   return data;

--- a/src/api/hooks/useUsers.ts
+++ b/src/api/hooks/useUsers.ts
@@ -4,11 +4,19 @@ import { usersApi } from '@/api/endpoints';
 import { mapUserResponse } from '@/api/dto/user.dto';
 import type { User } from '@/types/user';
 
+/**
+ * Composition function providing reactive state and helpers for fetching users.
+ *
+ * @returns Reactive references and a loader function that orchestrates the user request lifecycle.
+ */
 export const useUsers = () => {
   const users = ref<User[]>([]);
   const loading = ref(false);
   const error = ref<unknown>(null);
 
+  /**
+   * Fetch the users list and update the reactive state with the result.
+   */
   const fetchUsers = async () => {
     loading.value = true;
     error.value = null;

--- a/src/components/__tests__/HelloWorld.spec.ts
+++ b/src/components/__tests__/HelloWorld.spec.ts
@@ -3,6 +3,9 @@ import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import HelloWorld from '../HelloWorld.vue'
 
+/**
+ * Tests that ensure the HelloWorld component renders its message prop.
+ */
 describe('HelloWorld', () => {
   it('renders properly', () => {
     const wrapper = mount(HelloWorld, { props: { msg: 'Hello Vitest' } })

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Central export hub for commonly used UI components.
+ */
 export { default as BaseButton } from './base/BaseButton.vue';
 export { default as BaseInput } from './base/BaseInput.vue';
 export { default as AppHeader } from './layout/AppHeader.vue';

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -4,17 +4,29 @@ import { defineStore, storeToRefs } from 'pinia';
 import { authApi } from '@/api/endpoints';
 import { useUserStore } from '@/store/user.store';
 
+/**
+ * Pinia store managing authentication state and actions.
+ */
 export const useAuthStore = defineStore('auth', () => {
   const userStore = useUserStore();
 
   const token = computed(() => userStore.token);
   const isAuthenticated = computed(() => Boolean(token.value));
 
+  /**
+   * Authenticate a user and persist the received token in the user store.
+   *
+   * @param email - User email credential.
+   * @param password - User password credential.
+   */
   const login = async (email: string, password: string) => {
     const { token } = await authApi.login({ email, password });
     userStore.setToken(token);
   };
 
+  /**
+   * Clear the authentication state both locally and on the backend.
+   */
   const logout = async () => {
     await authApi.logout();
     userStore.clear();
@@ -28,6 +40,11 @@ export const useAuthStore = defineStore('auth', () => {
   };
 });
 
+/**
+ * Composition function exposing the auth store and its reactive state to components.
+ *
+ * @returns Reactive auth state and bound auth actions.
+ */
 export const useAuth = () => {
   const store = useAuthStore();
   const { token, isAuthenticated } = storeToRefs(store);

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,9 @@ import router from './router';
 
 import './assets/main.css';
 
+/**
+ * Root Vue application instance.
+ */
 const app = createApp(App);
 
 app.use(createPinia());

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,11 +3,17 @@ import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
 import privateRoutes from './routes/privateRoutes';
 import publicRoutes from './routes/publicRoutes';
 
+/**
+ * Complete set of routes available in the application.
+ */
 const routes: RouteRecordRaw[] = [
   ...publicRoutes,
   ...privateRoutes
 ];
 
+/**
+ * Vue Router instance configured with history mode and app routes.
+ */
 const router = createRouter({
   history: createWebHistory(),
   routes

--- a/src/router/routes/privateRoutes.ts
+++ b/src/router/routes/privateRoutes.ts
@@ -1,5 +1,8 @@
 import type { RouteRecordRaw } from 'vue-router';
 
+/**
+ * Routes that require the user to be authenticated before access.
+ */
 const privateRoutes: RouteRecordRaw[] = [
   {
     path: '/',

--- a/src/router/routes/publicRoutes.ts
+++ b/src/router/routes/publicRoutes.ts
@@ -1,5 +1,8 @@
 import type { RouteRecordRaw } from 'vue-router';
 
+/**
+ * Routes that are accessible without authentication.
+ */
 const publicRoutes: RouteRecordRaw[] = [
   {
     path: '/login',

--- a/src/store/user.store.ts
+++ b/src/store/user.store.ts
@@ -1,17 +1,31 @@
 import { defineStore } from 'pinia';
 
+/**
+ * Reactive state shape for the user store.
+ */
 interface UserState {
   token: string | null;
 }
 
+/**
+ * Pinia store holding the authenticated user's token.
+ */
 export const useUserStore = defineStore('user', {
   state: (): UserState => ({
     token: null
   }),
   actions: {
+    /**
+     * Persist the provided authentication token in the store.
+     *
+     * @param token - Authentication token returned from the server.
+     */
     setToken(token: string) {
       this.token = token;
     },
+    /**
+     * Remove any stored authentication information.
+     */
     clear() {
       this.token = null;
     }

--- a/src/stores/counter.ts
+++ b/src/stores/counter.ts
@@ -1,9 +1,15 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 
+/**
+ * Minimal example counter store used for scaffolding and demos.
+ */
 export const useCounterStore = defineStore('counter', () => {
   const count = ref(0)
   const doubleCount = computed(() => count.value * 2)
+  /**
+   * Increment the counter by one.
+   */
   function increment() {
     count.value++
   }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,3 +1,6 @@
+/**
+ * Representation of a user record within the application.
+ */
 export interface User {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- add JSDoc descriptions for API clients, endpoints, DTOs, and hooks
- document Pinia stores, router configuration, and common component exports
- annotate application bootstrap, shared types, and example tests for clarity

## Testing
- npm run test:unit *(fails: vitest not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daed1393c48323ac84d6759d299c26