### PR TITLE
Fix Storybook build by disabling devtools plugin

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath, URL } from 'node:url';
 
-import { mergeConfig } from 'vite';
+import { mergeConfig, type PluginOption } from 'vite';
 import type { StorybookConfig } from '@storybook/vue3-vite';
 
 const config: StorybookConfig = {
@@ -11,6 +11,22 @@ const config: StorybookConfig = {
     options: {}
   },
   viteFinal: async (config) => {
+    const disabledPlugins = new Set(['vite-plugin-vue-devtools', 'vite-plugin-inspect']);
+    const isNamedPlugin = (plugin: PluginOption): plugin is { name: string } =>
+      typeof plugin === 'object' &&
+      plugin !== null &&
+      !Array.isArray(plugin) &&
+      'name' in plugin &&
+      typeof (plugin as { name?: unknown }).name === 'string';
+
+    config.plugins = (config.plugins ?? []).filter((plugin) => {
+      if (!isNamedPlugin(plugin)) {
+        return true;
+      }
+
+      return !disabledPlugins.has(plugin.name);
+    });
+
     return mergeConfig(config, {
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- filter Storybook's Vite configuration to remove the Vue Devtools and inspect plugins that break the preview build

## Testing
- `npm run storybook -- --ci` *(fails: storybook binary not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daef8aa24c8323809680f372026bc9